### PR TITLE
deps: update system-configuration to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Update `system-configuration` crates.
-  See [PR_37](https://github.com/mxinden/if-watch/pull/37)
+- Update `system-configuration` crate.
+  See [PR_37](https://github.com/mxinden/if-watch/pull/37).
 
 ## [3.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [3.2.1]
+
+### Fixed
+
+- Update `system-configuration` crates.
+  See [PR_37](https://github.com/mxinden/if-watch/pull/37)
+
 ## [3.2.0]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rtnetlink = { version = "0.10.0", default-features = false }
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation = "0.9.2"
 if-addrs = "0.10.0"
-system-configuration = "0.5.0"
+system-configuration = "0.6.0"
 tokio = { version = "1.21.2", features = ["rt"], optional = true }
 smol = { version = "1.2.5", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "if-watch"
-version = "3.2.0"
+version = "3.2.1"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies Limited <admin@parity.io>"]
 edition = "2021"
 keywords = ["asynchronous", "routing"]


### PR DESCRIPTION
in the latest system-configuration, the IrDA interface types which will cause a link error on the latest ios has been deprecated.