### PR TITLE
chore: update actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Cache cargo folder
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cargo
         key: ${{ matrix.platform.target }}-cargo-${{ matrix.toolchain.rust }}
@@ -91,7 +91,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Cache cargo folder
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cargo
         key: lint-cargo


### PR DESCRIPTION
actions/cache v1 and v2 are getting deprecated on Ferbuary 1st.